### PR TITLE
chore: enable copy button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ gh_edit_repository: "https://github.com/glaredb/glaredb.github.io"
 gh_edit_branch: "main"
 gh_edit_view_mode: "tree"
 
-enable_copy_code_button: false
+enable_copy_code_button: true
 
 callouts_level: quiet # or loud
 callouts:

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -95,6 +95,8 @@ img {
 .highlight {
   border-radius: $border-radius;
 
+  // Selector with high specifity for "copy to clipboard" buttons.
+  // Relevant: _config.yaml enable_copy_code_button
   & ~ button[type="button"] {
     border: 1px solid #1f232826;
     border-radius: 6px;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -98,16 +98,17 @@ img {
   & ~ button[type="button"] {
     border: 1px solid #1f232826;
     border-radius: 6px;
-    display: none !important;
+    display: none !important; // See @include mq below
     margin: 6px;
     padding: 6px;
     opacity: 1;
     width: 18px;
 
     &:hover {
-      cursor: pointer;
+      cursor: pointer; // override just-the-docs default crosshair
     }
 
+    // They will only display on md+ screens, as otherwise they overlap content
     @include mq(md) {
       display: block !important;
     }

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -94,6 +94,24 @@ img {
 
 .highlight {
   border-radius: $border-radius;
+
+  & ~ button[type="button"] {
+    border: 1px solid #1f232826;
+    border-radius: 6px;
+    display: none !important;
+    margin: 6px;
+    padding: 6px;
+    opacity: 1;
+    width: 18px;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    @include mq(md) {
+      display: block !important;
+    }
+  }
 }
 
 body {


### PR DESCRIPTION
## Demo

![Copy button](https://github.com/GlareDB/glaredb.github.io/assets/11184711/93445109-7a0b-49f3-98cd-5f1d133d0e19)
![Copy Clicked](https://github.com/GlareDB/glaredb.github.io/assets/11184711/da024716-c1f1-4e44-8482-5526fbc3a9d4)
