### PR TITLE
chore: Check links with lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+# Exclude google font links since the roots 404, but are still used for
+# preconnecting.
+exclude = [
+  "https://fonts.gstatic.com/",
+  "https://fonts.googleapis.com/"
+]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "markdownlint-cli2 \"**/*.{md,mdx}\" \"!node_modules\" \"!_site\"",
-    "lint:fix": "markdownlint-cli2-fix \"**/*.{md,mdx}\" \"!node_modules\" \"!_site\""
+    "lint:fix": "markdownlint-cli2-fix \"**/*.{md,mdx}\" \"!node_modules\" \"!_site\"",
+    "links": "lychee -v http://localhost:4000"
   },
   "devDependencies": {
     "cspell": "^6.31.1",


### PR DESCRIPTION
Adds an npm script for running lychee against a locally running site.

https://github.com/lycheeverse/lychee