### PR TITLE
add pages for sql functions and sql commands

### DIFF
--- a/reference/aggregate-functions.md
+++ b/reference/aggregate-functions.md
@@ -1,8 +1,0 @@
----
-title: Aggregate Functions
-layout: default
-nav_order: 8
-parent: Reference
----
-
-## Aggregate Functions

--- a/reference/bindings.md
+++ b/reference/bindings.md
@@ -1,7 +1,7 @@
 ---
 title: Bindings Reference
 layout: default
-nav_order: 2
+nav_order: 3
 parent: Reference
 ---
 

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 layout: default
-nav_order: 1
+nav_order: 4
 parent: Reference
 ---
 

--- a/reference/predicate-functions.md
+++ b/reference/predicate-functions.md
@@ -1,8 +1,0 @@
----
-title: Predicate Functions
-layout: default
-nav_order: 6
-parent: Reference
----
-
-## Predicate Functions

--- a/reference/scalar-functions.md
+++ b/reference/scalar-functions.md
@@ -1,8 +1,0 @@
----
-title: Scalar Functions
-layout: default
-nav_order: 9
-parent: Reference
----
-
-## Scalar Functions

--- a/reference/sql-commands/alter-database.md
+++ b/reference/sql-commands/alter-database.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: ALTER DATABASE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# ALTER DATABASE
+
+Alter a database. The `default` database cannot be dropped.
+
+With this command, GlareDB supports:
+
+- renaming a database
+- setting the access mode of an external database
+
+## Syntax
+
+```sql
+ALTER DATABASE <database-name>
+  [RENAME TO <new-name>]
+  [SET ACCESS_MODE TO <access-mode>];
+```
+
+| Field           | Description                           |
+| --------------- | ------------------------------------- |
+| `database-name` | Name of the database to rename.       |
+| `new-name`      | New name for the database.            |
+| `access-mode`   | One of: \[`READ_WRITE`, `READ_ONLY`\] |
+
+Note that `new-name` must be unique within a GlareDB deployment.
+
+## Examples
+
+Rename database `db1` to `db2`. See [CREATE EXTERNAL DATABASE] for adding a
+database.
+
+```sql
+ALTER DATABASE db1 RENAME TO db2;
+```
+
+Create a Postgres data source and set it to `READ_ONLY`:
+
+```sql
+CREATE EXTERNAL DATABASE my_pg
+    FROM postgres
+    OPTIONS (
+        host = 'my.postgres.host',
+        port = '5432',
+        user = 'glaredb',
+        password = 'password',
+        database = 'glaredb_test',
+    );
+
+ALTER DATABASE my_pg SET ACCESS_MODE TO READ_ONLY;
+```
+
+[CREATE EXTERNAL DATABASE]: /glaredb/sql-commands/create-external-database/

--- a/reference/sql-commands/alter-table.md
+++ b/reference/sql-commands/alter-table.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: ALTER TABLE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# ALTER TABLE
+
+Alter a table. Builtin system tables cannot be altered. See [system
+catalog] for an overview of builtin tables and views.
+
+With this command, GlareDB supports:
+
+- renaming a table
+- setting the access mode of an external table
+
+## Syntax
+
+```sql
+ALTER TABLE <table-name>
+  [RENAME TO <new-name>]
+  [SET ACCESS_MODE TO <access-mode>];
+```
+
+| Field         | Description                           |
+| ------------- | ------------------------------------- |
+| `table-name`  | Name of the table to rename.          |
+| `new-name`    | New name for the table.               |
+| `access-mode` | One of: \[`READ_WRITE`, `READ_ONLY`\] |
+
+`table-name` may optionally be qualified with a schema.
+
+## Examples
+
+Rename table `t1` to `t2`. See [CREATE EXTERNAL TABLE] for adding a table.
+
+```sql
+ALTER TABLE t1 RENAME TO t2;
+```
+
+Add an Azure external table and set it to `READ_ONLY`. See [Azure Blob Storage]
+and [CREATE EXTERNAL TABLE] for more details.
+
+```sql
+CREATE EXTERNAL TABLE my_azure_table
+ FROM azure
+ OPTIONS (
+  account_name = '<azure-account>',
+  access_key = '<access-key>'
+  location = 'azure://<storage-container>/<object-path>'
+);
+
+ALTER TABLE my_azure_table SET ACCESS_MODE TO READ_ONLY;
+```
+
+[CREATE EXTERNAL TABLE]: /glaredb/sql-commands/create-external-table/
+[system catalog]: /glaredb/system-catalog/index/
+[Azure Blob Storage]: /docs/data-sources/supported/azure

--- a/reference/sql-commands/alter-tunnel.md
+++ b/reference/sql-commands/alter-tunnel.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: ALTER TUNNEL
+parent: SQL commands
+grand_parent: Reference
+---
+
+# ALTER TUNNEL
+
+Alter an SSH tunnel.
+
+GlareDB currently only supports rotating keys using this command. For more
+information on tunnels, see [Securing connections with SSH tunnels] and
+[CREATE TUNNEL].
+
+{: .important}
+
+> After you rotate keys, don't forget to update your SSH server with the new
+> public key.
+
+## Syntax
+
+```sql
+ALTER TUNNEL [IF EXISTS] <tunnel-name> ROTATE KEYS;
+```
+
+| Field         | Description                  |
+| ------------- | ---------------------------- |
+| `tunnel-name` | Name of the tunnel to alter. |
+
+## Examples
+
+Creates a tunnel named `my_tunnel` then rotates its keys.
+
+```sql
+CREATE TUNNEL my_tunnel
+  FROM ssh
+  OPTIONS (
+    host = 'my.tunnel.host',
+    port = '22',
+    user = 'example_user'
+  );
+
+ALTER TUNNEL my_tunnel ROTATE KEYS;
+```
+
+[Securing connections with SSH tunnels]: /docs/data-sources/securing-connections.html#securing-connections-with-ssh-tunnels
+[CREATE TUNNEL]: /glaredb/sql-commands/create-tunnel/

--- a/reference/sql-commands/begin.md
+++ b/reference/sql-commands/begin.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: BEGIN
+parent: SQL commands
+grand_parent: Reference
+---
+
+# BEGIN
+
+`BEGIN` currently has no affect. See [Transactions] for our current transaction
+support.
+
+[Transactions]: /glaredb/transactions/

--- a/reference/sql-commands/commit.md
+++ b/reference/sql-commands/commit.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: COMMIT
+parent: SQL commands
+grand_parent: Reference
+---
+
+# COMMIT
+
+`COMMIT` currently has no affect. See [Transactions] for our current transaction
+support.
+
+[Transactions]: /glaredb/transactions/

--- a/reference/sql-commands/copy-to.md
+++ b/reference/sql-commands/copy-to.md
@@ -1,0 +1,152 @@
+---
+layout: default
+title: COPY TO
+parent: SQL commands
+grand_parent: Reference
+---
+
+# COPY TO
+
+Copy rows from a table or query to local files or supported object stores.
+
+## Syntax
+
+```sql
+-- Copy the output of a query, or table, to a local path
+COPY [(<query>) | <table>] TO '<location>' [FORMAT format];
+-- Alternative syntax for local copying
+COPY [(<query>) | <table>] TO LOCAL [FORMAT format] OPTIONS (
+  location = '<location>'
+);
+
+-- Copy the output of a query or table to GCS
+COPY [(<query>) | <table>] TO gcs [FORMAT format] OPTIONS (
+  bucket = '<bucket>',
+  location = '<location>',
+  service_account_key = '<gcp_service_account_key>'
+)
+-- Alternative syntax for copying to GCS with OPTIONS
+COPY [(<query>) | <table>] TO '<gcs_url>' [FORMAT format] OPTIONS (
+  service_account_key = '<gcp_service_account_key>'
+);
+-- Alternative syntax for copying to GCS with a CREDENTIALS database object
+COPY [(<query>) | <table>] TO '<gcs_url>' [FORMAT format]
+CREDENTIALS gcp_credentials;
+
+-- Copy the output of a query or table to S3 with OPTIONS
+COPY [(<query>) | <table>] TO s3 [FORMAT format] OPTIONS (
+  access_key_id = '<aws_access_key_id>',
+  bucket = '<bucket>',
+  location = '<location>',
+  region = '<aws_region>',
+  secret_access_key = '<aws_secret_access_key>'
+);
+-- Alternative syntax for copying S3 with OPTIONS
+COPY [(<query>) | <table>] TO '<s3_url>' [FORMAT format] OPTIONS (
+        access_key_id = '<aws_access_key_id>',
+        region = '<aws_region>',
+        secret_access_key = '<aws_secret_access_key>'
+);
+-- Alternative syntax for copying to S3 with a CREDENTIALS database object
+COPY [(<query>) | <table>] TO '<s3_url>' [FORMAT format]
+CREDENTIALS s3_credentials ( region '<aws_region>' );
+```
+
+| Field                     | Destination | Description                                                                  |
+| ------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `aws_region`              | S3          | The region of the bucket.                                                    |
+| `aws_access_key_id`       | S3          | ID of AWS access key with permissions to write the bucket.                   |
+| `aws_secret_access_key`   | S3          | Secret associated with the AWS access key.                                   |
+| `bucket`                  | GCS or S3   | Name of the bucket.                                                          |
+| `format`                  | All         | Output format. One of **csv** (default), **json**, **bson**, or **parquet**. |
+| `gcp_credentials`         | GCS         | A database object containing GCP credentials.                                |
+| `gcp_service_account_key` | GCS         | A JSON-encoded GCP service account key with access to the bucket.            |
+| `gcs_url`                 | GCS         | A url in the format gs://bucket/location                                     |
+| `location`                | All         | A path to copy to.                                                           |
+| `query`                   | All         | The query to execute, of which the results will be copied.                   |
+| `s3_credentials`          | S3          | A database object containing S3 credentials.                                 |
+| `s3_url`                  | S3          | A url in the format s3://bucket/location                                     |
+| `table`                   | All         | A fully-qualified table name.                                                |
+
+## Usage
+
+### Local files
+
+A query or table may be copied to a local file.
+
+```sql
+-- copy the result of 'select 1' to result.parquet in the current directory
+COPY (select 1) TO 'result.parquet' FORMAT parquet;
+-- Same as above with OPTIONS syntax
+COPY (select 1) TO LOCAL FORMAT parquet OPTIONS (location = 'result.parquet');
+-- copy all rows of the users table to /tmp/users.json
+COPY public.users TO '/tmp/users.json' FORMAT json;
+-- Same as above with OPTIONS syntax
+COPY public.users TO LOCAL FORMAT json OPTIONS (location = '/tmp/users.json');
+```
+
+### Copying files to GCS
+
+Files in GCS can be copied to by providing the path to the file and credentials.
+The service account key provided should be JSON encoded.
+
+```sql
+-- copy the result of 'select 1' to results.csv in a bucket
+COPY ( SELECT 1 ) TO gcs OPTIONS (
+  bucket = 'bucket',
+  location = 'results.csv'
+  service_account_key = 'gcp_service_account_key',
+);
+-- same as above, but using a URL and OPTIONS
+COPY ( SELECT 1 ) TO 'gs://bucket/results.csv' OPTIONS (
+  service_account_key = 'gcp_service_account_key'
+);
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp (
+  service_account_key '<service_account_key>'
+);
+-- And use them in copy public.users.
+COPY public.users TO 'gs://bucket/users.json' FORMAT json
+CREDENTIALS my_gcp_creds;
+```
+
+### Copying files to S3
+
+Files in S3 can be copied to by providing the path to the file and credentials.
+
+```sql
+-- copy the result of 'select 1' to results.csv in a bucket
+COPY ( SELECT 1 ) TO s3 OPTIONS (
+  access_key_id = '<aws_access_key_id>',
+  bucket = '<bucket>',
+  location = 'results.csv',
+  region = '<aws_region>',
+  secret_access_key = '<aws_secret_access_key>'
+);
+-- same as above, but using a URL and OPTIONS
+COPY ( SELECT 1 ) TO 's3://bucket/results.csv' OPTIONS (
+  access_key_id = '<aws_access_key_id>',
+  region = '<aws_region>',
+  secret_access_key = '<aws_secret_access_key>'
+);
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws OPTIONS (
+  access_key_id = '<aws_access_key_id>',
+  secret_access_key = '<aws_secret_access_key>',
+);
+-- And use them in copy public.users.
+COPY public.users TO 's3://bucket/users.json' FORMAT json
+CREDENTIALS my_aws_creds ( region '<aws_region>' );
+```

--- a/reference/sql-commands/create-credentials.md
+++ b/reference/sql-commands/create-credentials.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: CREATE CREDENTIALS
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE CREDENTIALS
+
+Create credentials for accessing AWS and Google Cloud resources.
+
+## Syntax
+
+```sql
+CREATE CREDENTIALS <credential-name>
+    PROVIDER <provider>
+    OPTIONS (<provider-options>);
+```
+
+| Field              | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `credential-name`  | Name for the credentials.                                          |
+| `provider`         | Cloud provider these credentials are for. Values: \[`aws`, `gcp`\] |
+| `provider-options` | Provider specific options. See below.                              |
+
+## AWS credentials
+
+AWS credentials allow GlareDB to read and write objects in S3.
+
+Creating AWS credentials requires `access_key_id` and `secret_access_key`. These
+correspond to an IAM user with permissions for accessing objects in S3.
+
+```sql
+CREATE CREDENTIALS my_aws_creds
+PROVIDER aws
+OPTIONS (
+    access_key_id = 'my_access_key_id',
+    secret_access_key = 'my_secret_access_key',
+);
+```
+
+After creating the credentials, they can be used to access objects in S3:
+
+```sql
+SELECT * FROM parquet_scan(
+    's3://my_bucket/data/*.parquet',
+    my_aws_creds,
+    region => 'us-east-1'
+);
+```
+
+As another example, the credentials can be used to write output of a query to
+S3:
+
+```sql
+COPY ( SELECT 5 AS a, 6 AS b )
+TO 's3://my_bucket/data/output.parquet'
+CREDENTIALS my_aws_creds ( region 'us-east-1' );
+```
+
+These examples require specifying `region`. GlareDB requires a `region` when
+connecting to an S3 resource. Use the AWS region of the bucket.
+
+## GCP credentials
+
+GCP credentials allow GlareDB to read and write objects in GCS.
+
+The **service_account_key** option is required when creating GCP credentials.
+service_account_key is a JSON-encoded key for a service account. Only buckets
+that this service account has read permissions for can be queryed.
+
+```sql
+CREATE CREDENTIALS my_gcp_creds
+PROVIDER gcp
+OPTIONS (
+    service_account_key = 'my_gcp_service_account_key',
+);
+```
+
+After creating the credentials, they can be used to access objects in GCS:
+
+```sql
+SELECT * FROM parquet_scan(
+    'gs://my_bucket/data/*.parquet',
+    my_gcp_creds
+);
+```
+
+As another example, the credentials can be used to write output of a query to
+GCS:
+
+```sql
+COPY ( SELECT 5 AS a, 6 AS b )
+TO 'gs://my_bucket/data/output.parquet'
+CREDENTIALS my_gcp_creds;
+```

--- a/reference/sql-commands/create-external-database.md
+++ b/reference/sql-commands/create-external-database.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: CREATE EXTERNAL DATABASE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE EXTERNAL DATABASE
+
+Use an external database as a data source in GlareDB. See [Data sources] to
+learn more.
+
+## Syntax
+
+```sql
+CREATE EXTERNAL DATABASE <database-name>
+    FROM <data-source-type>
+    [TUNNEL <tunnel-name>]
+    OPTIONS (<data-source-options>);
+```
+
+| Field                 | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `database-name`       | Name of the database as it appears in GlareDB.   |
+| `data-source-type`    | The type of data source, for example `postgres`. |
+| `tunnel-name`         | [SSH tunnel] to connect with.                    |
+| `data-source-options` | Options specific to this data source type.       |
+
+Note that `database-name` must be unique within a GlareDB deployment.
+
+## Examples
+
+Create an external database named `external_db` using a Postgres data source.
+
+```sql
+CREATE EXTERNAL DATABASE external_db
+    FROM postgres
+    OPTIONS (
+        host = 'my.postgres.host',
+        port = '5432',
+        user = 'glaredb',
+        password = 'password',
+        database = 'glaredb_test',
+    );
+```
+
+[Data sources]: /docs/data-sources
+[SSH tunnel]: /docs/data-sources/securing-connections.html

--- a/reference/sql-commands/create-external-table.md
+++ b/reference/sql-commands/create-external-table.md
@@ -1,0 +1,84 @@
+---
+layout: default
+title: CREATE EXTERNAL TABLE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE EXTERNAL TABLE
+
+Create an external table backed by a data source.
+
+## Syntax
+
+```sql
+CREATE EXTERNAL TABLE [IF NOT EXISTS] <table-name>
+    FROM <data-source-type>
+    [TUNNEL <tunnel-name>]
+    OPTIONS (<data-source-options>);
+```
+
+| Field                 | Description                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `table-name`          | Name of the database as it appears in GlareDB.                                                                                                 |
+| `data-source-type`    | The type of data source: \[`bigquery`, `delta`, `gcs`, `iceberg`, `mongo`, `mysql`, `postgres`, `s3`, `snowflake`, `bson`, `lance`, `azure`\]. |
+| `tunnel-name`         | [SSH tunnel] to connect with.                                                                                                                  |
+| `data-source-options` | Options specific to this data source type.                                                                                                     |
+
+`table-name` may optionally be qualified with a schema.
+
+Specifying `IF NOT EXISTS` will suppress an error if `schema-name` already
+exists.
+
+## Examples
+
+### Delta
+
+In this example an external table named `my_delta_table` is created from a file
+in GCS.
+
+```sql
+CREATE EXTERNAL TABLE my_delta_table
+    FROM delta
+    OPTIONS (
+        location 'gs://<bucket_name>/<path_to_delta_table>',
+        service_account_key '<gcp_service_account>'
+    );
+```
+
+Alternatively, a [credentials object] can be created and used:
+
+```sql
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+
+
+CREATE EXTERNAL TABLE my_delta_table
+    FROM delta
+    CREDENTIALS my_gcp_creds
+    OPTIONS (
+        location 'gs://<bucket_name>/<path_to_delta_table>',
+    );
+```
+
+### Postgres
+
+In this example an external table named `external_table` is created using a
+Postgres table `public.users` as a data source.
+
+```sql
+CREATE EXTERNAL TABLE external_table
+    FROM postgres
+    OPTIONS (
+        host = 'my.postgres.host',
+        port = '5432',
+        user = 'glaredb',
+        password = 'password',
+        database = 'glaredb_test',
+        schema = 'public',
+        table = 'users'
+    );
+```
+
+[SSH tunnel]: /docs/data-sources/securing-connections.html
+[credentials object]: /glaredb/sql-commands/create-credentials/

--- a/reference/sql-commands/create-schema.md
+++ b/reference/sql-commands/create-schema.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: CREATE SCHEMA
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE SCHEMA
+
+Create a schema in the `default` database.
+
+## Syntax
+
+```sql
+CREATE SCHEMA [IF NOT EXISTS] <schema-name>;
+```
+
+| Field         | Description         |
+| ------------- | ------------------- |
+| `schema-name` | Name of the schema. |
+
+Specifying `IF NOT EXISTS` will suppress an error if `schema-name` already
+exists.
+
+## Examples
+
+Create a schema named `my_schema` if it doesn't already exist.
+
+```sql
+CREATE SCHEMA IF NOT EXISTS my_schema;
+```

--- a/reference/sql-commands/create-table.md
+++ b/reference/sql-commands/create-table.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: CREATE TABLE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE TABLE
+
+Create a native table.
+
+{: .important}
+
+> GlareDB does not yet support UPDATE for native tables.
+
+## Syntax
+
+```sql
+-- defining a table, optionally with VALUES
+CREATE [TEMP] TABLE table_name (column_name data_type [, ... ])
+  [AS VALUES (value)[, ... ]];
+-- creating a table from a SELECT
+CREATE [TEMP] TABLE table_name AS select_statement;
+-- creating a table from a SELECT with aliasing and casting
+CREATE [TEMP] TABLE table_name (column_name data_type [, ...])
+  AS select_statement;
+```
+
+| Field              | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `column_name`      | Name of a column.                                 |
+| `data_type`        | Data type of a column.                            |
+| `select_statement` | A [`SELECT`] query to create the table from.      |
+| `table_name`       | Name of the table.                                |
+| `value`            | A value set to insert into the table on creation. |
+
+### Temporary tables
+
+When creating a table with `TEMP` specified, the table is **never** qualified
+with a schema. The table will exist in the `current_session` schema and will be
+dropped once the session has ended.
+
+## Examples
+
+In this example a simple users table is created with two users:
+
+```sql
+CREATE TABLE public.users ( name text, email text ) AS VALUES
+  ('Pris', 'pris@stratton.net'),
+  ('Eldon Tyrell', 'ceo@tyrell.corp');
+```
+
+In this example, we create a table schema and values from [`generate_series`].
+
+```sql
+CREATE TABLE public.ints AS select * from generate_series(1, 10);
+```
+
+In these examples, we leverage casting and aliasing when creating a table and
+values from a [`SELECT`]. Note that not all columns need to be aliased. The
+provided values will be casted to match the column data type.
+
+```sql
+-- The first column will be aliased to 'a' and cast to Int32. The second column
+-- will be unnamed at Int64.
+CREATE TABLE public.example (a int) AS VALUES (1, 2);
+
+-- Both columns are aliased and cast from values. The first column will be 'a'
+-- and the value 1 is cast to Int32. The second column will be 'b' and the value
+-- 2 is cast to Utf8 text.
+CREATE TABLE public.example2 (a int, b text) as values (1, 2);
+```
+
+[`SELECT`]: /glaredb/sql-commands/select/
+[`generate_series`]: /glaredb/sql-functions/generate_series/

--- a/reference/sql-commands/create-tunnel.md
+++ b/reference/sql-commands/create-tunnel.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: CREATE TUNNEL
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE TUNNEL
+
+Create an SSH Tunnel
+
+## Syntax
+
+```sql
+CREATE TUNNEL <tunnel-name>
+  FROM ssh
+  OPTIONS (
+    host = '<host>',
+    port = '<port>',
+    user = '<user>'
+  );
+```
+
+| Field           | Description                               |
+| --------------- | ----------------------------------------- |
+| `<tunnel-name>` | A friendly name for the tunnel            |
+| `<host>`        | The location of the SSH server            |
+| `<port>`        | The port of the SSH server (default `22`) |
+| `<user>`        | SSH user                                  |
+
+## Examples
+
+The following example creates a tunnel named `my_tunnel`, and uses it to connect
+to a postgres data source.
+
+```sql
+CREATE TUNNEL my_tunnel
+  FROM ssh
+  OPTIONS (
+    host = 'my.tunnel.host',
+    port = '22',
+    user = 'example_user'
+  );
+
+CREATE EXTERNAL DATABASE my_pg
+    FROM postgres
+    TUNNEL my_tunnel
+    OPTIONS (
+        host = 'my.postgres.host',
+        port = '5432',
+        user = 'glaredb',
+        password = 'password',
+        database = 'glaredb_test',
+    );
+```

--- a/reference/sql-commands/create-view.md
+++ b/reference/sql-commands/create-view.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: CREATE VIEW
+parent: SQL commands
+grand_parent: Reference
+---
+
+# CREATE VIEW
+
+Create a view.
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] VIEW <view-name> AS <select-statement>;
+```
+
+| Field              | Description                               |
+| ------------------ | ----------------------------------------- |
+| `view-name`        | Name of the view.                         |
+| `select-statement` | The select statement to use for the view. |
+
+`view-name` may optionally be qualified with a schema.
+
+If `OR REPLACE` is specified and a view with `view-name` already exists, the
+view's definition will be replaced with the new `select-statement`.
+
+## Examples
+
+Create a view named `simple_select` that selects the value "1".
+
+```sql
+CREATE VIEW simple_select AS SELECT 1;
+```

--- a/reference/sql-commands/delete.md
+++ b/reference/sql-commands/delete.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: DELETE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DELETE
+
+The SQL standard for `DELETE` is large and powerful
+so that you can delete rows from a table with precise
+control. GlareDB supports most of the [PostgreSQL `DELETE`]
+syntax and will eventually have full support.
+
+## Syntax
+
+```sql
+DELETE FROM table_name
+    [ WHERE condition ]
+```
+
+| Field        | Description                                   |
+| ------------ | --------------------------------------------- |
+| `table_name` | Source table to delete from                   |
+| `condition`  | An SQL expression that evaluates to a boolean |
+
+## Examples
+
+Delete all rows from table `table1`.
+
+```sql
+DELETE FROM table1;
+```
+
+Delete rows from table `table2` where column `col_int` has a value greater than 10.
+
+```sql
+DELETE FROM table2
+  WHERE col_int > 10;
+```
+
+[PostgreSQL `DELETE`]: https://www.postgresql.org/docs/current/sql-delete.html

--- a/reference/sql-commands/drop-database.md
+++ b/reference/sql-commands/drop-database.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: DROP DATABASE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DROP DATABASE
+
+Drop a database. The `default` database cannot be dropped.
+
+Note that this does not make any modifications to the external data source, and
+only means the database can no longer be accessed from within GlareDB.
+
+## Syntax
+
+```sql
+DROP DATABASE [IF EXISTS] <database>;
+```
+
+| Field      | Description           |
+| ---------- | --------------------- |
+| `database` | The database to drop. |
+
+## Examples
+
+Drop a database named `pg`. See [CREATE EXTERNAL DATABASE] for adding a database.
+
+```sql
+DROP DATABASE pg;
+```
+
+[CREATE EXTERNAL DATABASE]: /glaredb/sql-commands/create-external-database/

--- a/reference/sql-commands/drop-schema.md
+++ b/reference/sql-commands/drop-schema.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: DROP SCHEMA
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DROP SCHEMA
+
+Drop a schema. Note that builtin schemas cannot be dropped. See [system catalog]
+for an overview of builtin schemas.
+
+## Syntax
+
+```sql
+DROP SCHEMA [IF EXISTS] <schema-name> [CASCADE];
+```
+
+| Field        | Description        |
+| ------------ | ------------------ |
+| `table-name` | The table to drop. |
+
+`schema-name` may optionally be qualified with a schema name.
+
+If `CASCADE` is specified, all child tables and views will also be dropped. If
+`CASCADE` is omitted, the command will error if any tables or views exist in the
+schema.
+
+## Examples
+
+Drop a schema named `my_schema`, also dropping all tables and views within that
+schema. See [CREATE SCHEMA] for how to create a schema.
+
+```sql
+DROP SCHEMA my_schema CASCADE;
+```
+
+[CREATE SCHEMA]: /glaredb/sql-commands/create-schema/
+[system catalog]: /glaredb/system-catalog/index/

--- a/reference/sql-commands/drop-table.md
+++ b/reference/sql-commands/drop-table.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: DROP TABLE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DROP TABLE
+
+Drop a table. Note that builtin system tables cannot be dropped. See [system
+catalog] for an overview of builtin tables and views.
+
+## Syntax
+
+```sql
+DROP TABLE [IF EXISTS] <table-name>;
+```
+
+| Field        | Description        |
+| ------------ | ------------------ |
+| `table-name` | The table to drop. |
+
+`table-name` may optionally be qualified with a schema name.
+
+## Examples
+
+Drop a table named `my_table`. See [CREATE EXTERNAL TABLE] for how to create an
+external table.
+
+```sql
+DROP TABLE my_table;
+```
+
+[CREATE EXTERNAL TABLE]: /glaredb/sql-commands/create-external-table/
+[system catalog]: /glaredb/system-catalog/index/

--- a/reference/sql-commands/drop-tunnel.md
+++ b/reference/sql-commands/drop-tunnel.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: DROP TUNNEL
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DROP TUNNEL
+
+Drop a tunnel.
+
+## Syntax
+
+```sql
+DROP TUNNEL [IF EXISTS] <tunnel-name>;
+```
+
+| Field         | Description         |
+| ------------- | ------------------- |
+| `tunnel-name` | The tunnel to drop. |
+
+## Examples
+
+Drop a tunnel named `my_tunnel`. See [CREATE TUNNEL] for how to create a
+tunnel.
+
+```sql
+DROP TUNNEL my_tunnel;
+```
+
+[CREATE TUNNEL]: /glaredb/sql-commands/create-tunnel/

--- a/reference/sql-commands/drop-view.md
+++ b/reference/sql-commands/drop-view.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: DROP VIEW
+parent: SQL commands
+grand_parent: Reference
+---
+
+# DROP VIEW
+
+Drop a view. Note that builtin system views cannot be dropped. See [system
+catalog] for an overview of builtin tables and views.
+
+## Syntax
+
+```sql
+DROP VIEW [IF EXISTS] <view-name>;
+```
+
+| Field       | Description       |
+| ----------- | ----------------- |
+| `view-name` | The view to drop. |
+
+`view-name` may optionally be qualified with a schema name.
+
+## Examples
+
+Drop a view named `my-view`. See [CREATE VIEW] for how to create a view.
+
+```sql
+DROP VIEW my-view;
+```
+
+[CREATE VIEW]: /glaredb/sql-commands/create-view/
+[system catalog]: /glaredb/system-catalog/index/

--- a/reference/sql-commands/index.md
+++ b/reference/sql-commands/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: SQL commands
+has_children: true
+nav_order: 1
+parent: Reference
+---
+
+# SQL command reference
+
+Reference docs for SQL commands supported in GlareDB.

--- a/reference/sql-commands/insert-into.md
+++ b/reference/sql-commands/insert-into.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: INSERT INTO
+parent: SQL commands
+grand_parent: Reference
+---
+
+# INSERT INTO
+
+Insert data into a native table.
+
+{: .important}
+
+> GlareDB does not yet support UPDATE for native tables.
+
+## Syntax
+
+```sql
+INSERT INTO table_name VALUES (value)[, ... ];
+```
+
+| Field        | Description                           |
+| ------------ | ------------------------------------- |
+| `table_name` | Name of the table.                    |
+| `value`      | A value set to insert into the table. |
+
+## Examples
+
+In this example we'll first [`CREATE`] a simple users table, then insert two
+users into it.
+
+```sql
+CREATE TABLE public.users ( name text, email text );
+
+INSERT INTO public.users AS VALUES
+  ('Pris', 'pris@stratton.net'),
+  ('Eldon Tyrell', 'ceo@tyrell.corp');
+```
+
+[`CREATE`]: /glaredb/sql-commands/create-table/

--- a/reference/sql-commands/rollback.md
+++ b/reference/sql-commands/rollback.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: ROLLBACK
+parent: SQL commands
+grand_parent: Reference
+---
+
+# ROLLBACK
+
+`ROLLBACK` currently has no affect. See [Transactions] for our current transaction
+support.
+
+[Transactions]: /glaredb/transactions/

--- a/reference/sql-commands/select.md
+++ b/reference/sql-commands/select.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: SELECT
+parent: SQL commands
+grand_parent: Reference
+---
+
+# SELECT
+
+The SQL standard for `SELECT` is large and powerful so that you can query data
+with very precise parameters. GlareDB supports most of the [PostgreSQL `SELECT`]
+syntax and will eventually have full support.
+
+## Syntax
+
+```sql
+SELECT [ DISTINCT ]
+    [ * [ EXCLUDE ( column [, ...] ) ] | expression [ [ AS ] output_name ] [, ...] ]
+    [ FROM from_item [, ...] ]
+    [ WHERE condition ]
+    [ GROUP BY [ DISTINCT ] grouping_element [, ...] ]
+    [ HAVING condition ]
+    [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
+    [ ORDER BY expression [ ASC | DESC | USING operator ] [ NULLS { FIRST | LAST } ] [, ...] ]
+    [ LIMIT { count | ALL } ]
+    [ OFFSET start [ ROW | ROWS ] ]
+```
+
+| Field              | Description                                   |
+| ------------------ | --------------------------------------------- |
+| `expression`       | An SQL expression                             |
+| `output_name`      | An alias (alternative name)                   |
+| `from_item`        | Source table or path to file to select from   |
+| `condition`        | An SQL expression that evaluates to a boolean |
+| `grouping_element` | Column to group on                            |
+| `operator`         | `UNION`, `INTERSECT` or `EXCEPT` operator     |
+| `count`            | Number (ex: of rows to limit)                 |
+| `start`            | Number (ex: of rows to offset)                |
+
+## Examples
+
+There are _many_ formats of select queries. In the following example a data
+source named `pg` with a `public` schema and `users` table is queryed. The query
+looks for all names starting with `G` and returns a count of duplicates.
+
+```sql
+select name, count(id) as count
+  from pg.public.users
+  group by name
+  having name like 'G%'
+  order by name asc;
+```
+
+```text
+       name       | count
+------------------+-------
+ Gary             |     1
+ Gloria           |     2
+(2 rows)
+
+```
+
+### Exclude clause
+
+The `EXCLUDE` clause will select all columns except those specified.
+
+```sql
+-- select all columns except id
+SELECT * EXCLUDE (id) FROM pg.public.users;
+```
+
+[PostgreSQL `SELECT`]: https://www.postgresql.org/docs/current/sql-select.html

--- a/reference/sql-commands/update.md
+++ b/reference/sql-commands/update.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: UPDATE
+parent: SQL commands
+grand_parent: Reference
+---
+
+# UPDATE
+
+The SQL standard for `UPDATE` is large and powerful
+so that you can update rows from a table with precise
+control. GlareDB supports most of the [PostgreSQL `UPDATE`]
+syntax and will eventually have full support.
+
+## Syntax
+
+```sql
+UPDATE table_name
+    SET column = value_expr [, ...]
+    [ WHERE condition ]
+```
+
+| Field        | Description                                                 |
+| ------------ | ----------------------------------------------------------- |
+| `table_name` | The fully-qualified table name to update (ex: public.users) |
+| `column`     | A column to update. Column is not qualified (ex: name)      |
+| `value_expr` | An SQL expression that evaluates to the column value        |
+| `condition`  | An SQL expression that evaluates to a boolean               |
+
+## Examples
+
+Update all rows from table `table1` and set value of col1 to 3.
+
+```sql
+UPDATE table1
+  SET col1 = 3;
+```
+
+Update rows from table `table2` and set columns `col1` and `col2` to
+2 and 4 respectively, where column `col2` has value 3.
+
+```sql
+UPDATE table2
+  SET col1 = 2, col2 = 4
+  WHERE col2 = 3;
+```
+
+[PostgreSQL `UPDATE`]: https://www.postgresql.org/docs/current/sql-update.html

--- a/reference/sql-functions.md
+++ b/reference/sql-functions.md
@@ -1,8 +1,0 @@
----
-title: SQL Functions
-layout: default
-nav_order: 4
-parent: Reference
----
-
-## SQL Functions

--- a/reference/sql-functions/csv_scan.md
+++ b/reference/sql-functions/csv_scan.md
@@ -1,0 +1,175 @@
+---
+layout: default
+title: csv_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `csv_scan`
+
+Read csv files from a local filesystem or supported object stores.
+
+The files may be compressed, for example: `.csv.gz`.
+
+URLs provided to `csv_scan` may also include glob characters to allow
+scanning multiple files when reading from S3, GCS, or a local filesystem.
+Globbed paths are not allowed when querying csv files over HTTP/HTTPS.
+
+## Syntax
+
+```sql
+-- Single url or path.
+csv_scan(<url>)
+-- Multiple urls or paths.
+csv_scan([<url>])
+-- Using a cloud credentials object.
+csv_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+csv_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+csv_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+csv_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a csv file to scan.                                     |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+## Usage
+
+### Local files
+
+Local files can be read by passing the path or a globbed path to `csv_scan`.
+Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM csv_scan('./my_data.csv');
+-- Read all csv files in a directory.
+SELECT * FROM csv_scan('./directory_of_data/*.csv');
+-- Read csv files from multiple directories.
+SELECT * FROM csv_scan('./**/*.csv');
+-- Read multiple explicitly provided files.
+SELECT * FROM csv_scan(['./directory_of_data/1.csv', './directory_of_data/2.csv']);
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `csv_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM csv_scan('gs://my-bucket/path/object.csv',
+                           service_account_key => '<service_account_key>');
+-- Scan objects matching a glob.
+SELECT * FROM csv_scan('gs://my-bucket/path/prefix_*.csv',
+                           service_account_key => '<service_account_key>');
+-- Read all objects in a directory.
+SELECT * FROM csv_scan('gs://my-bucket/path/*',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM csv_scan('gs://my-bucket/path/object.csv', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `csv_scan`.
+
+```sql
+SELECT * FROM csv_scan('gs://my-bucket/path/object.csv',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+-- Scan objects matching a glob.
+SELECT * FROM csv_scan('gs://my-bucket/path/prefix_*.csv',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+-- Read all objects in a directory.
+SELECT * FROM csv_scan('gs://my-bucket/path/prefix_*.csv',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM csv_scan('gs://my-bucket/path/object.csv', my_aws_creds, region => 'us-east-1');
+```
+
+### HTTP files
+
+CSV files can also be scanned over HTTP/HTTPS.
+
+```sql
+-- Read a single file.
+SELECT * FROM csv_scan('https://my_domain.com/file.csv');
+-- Read multiple files
+SELECT * FROM csv_scan(['https://my_domain.com/1.csv', 'https://my_domain.com/2.csv']);
+```
+
+{: .important}
+
+> Globbed paths are not supported when reading csv files over HTTP/HTTPS
+
+## Examples
+
+In the following example we use [COPY TO] to create a csv file and finally
+read it with `csv_scan`.
+
+```sql
+-- Output the file to 'example.csv'
+COPY (SELECT * FROM generate_series(1, 10)) TO 'example.csv';
+
+-- And scan it back in.
+SELECT * FROM csv_scan('./example.csv');
+
+-- Output:
+-- ┌─────────────────┐
+-- │ generate_series │
+-- │ ──              │
+-- │ Int64           │
+-- ╞═════════════════╡
+-- │ 1               │
+-- │ 2               │
+-- │ 3               │
+-- │ 4               │
+-- │ 5               │
+-- │ 6               │
+-- │ 7               │
+-- │ 8               │
+-- │ 9               │
+-- │ 10              │
+-- └─────────────────┘
+```
+
+[COPY TO]: /glaredb/sql-commands/copy-to

--- a/reference/sql-functions/delta_scan.md
+++ b/reference/sql-functions/delta_scan.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: delta_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `delta_scan`
+
+Read a Delta Lake table from the local filesystem or supported object store.
+
+## Syntax
+
+```sql
+-- Single url or path.
+delta_scan(<url>)
+-- Using a cloud credentials object.
+delta_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+delta_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+delta_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+delta_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a delta table to scan.                                  |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+The path or URL provided to `delta_scan` should be to a directory containing a
+`_delta_log/` directory.
+
+## Usage
+
+### Local files
+
+Local Delta table can be read with `delta_scan` by passing in a path to the
+table. Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM delta_scan('./directory/my_delta_table/');
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `delta_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM delta_scan('gs://my-bucket/path/delta_table',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM delta_scan('gs://my-bucket/path/delta_table', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `delta_scan`.
+
+```sql
+SELECT * FROM delta_scan('gs://my-bucket/path/delta_table',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM delta_scan('gs://my-bucket/path/delta_table', my_aws_creds, region => 'us-east-1');
+```

--- a/reference/sql-functions/generate_series.md
+++ b/reference/sql-functions/generate_series.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: generate_series
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `generate_series`
+
+Generate a series of integers or decimals.
+
+## Syntax
+
+```sql
+generate_series(<start>, <stop> [, <step>])
+```
+
+| Field   | Description                                       |
+| ------- | ------------------------------------------------- |
+| `start` | The integer or decimals to start generating from. |
+| `stop`  | The integer or decimals to stop generating at.    |
+| `step`  | The step size (defaults to 1).                    |
+
+## Examples
+
+The following generates even numbers from 0 to 10.
+
+```sql
+select * from generate_series(0, 10, 2);
+```
+
+The following generates decimals from 0.0 to 1.0, stepping by 0.1:
+
+```sql
+select * from generate_series(0, 1, 0.1);
+```

--- a/reference/sql-functions/iceberg_scan.md
+++ b/reference/sql-functions/iceberg_scan.md
@@ -1,0 +1,105 @@
+---
+layout: default
+title: iceberg_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `iceberg_scan`
+
+Read an Iceberg table from the local filesystem or supported object store.
+
+Iceberg support is early. Additional Iceberg related features are being tracked
+in [Issue #1448].
+
+## Syntax
+
+```sql
+-- Single url or path.
+iceberg_scan(<url>)
+-- Using a cloud credentials object.
+iceberg_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+iceberg_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+iceberg_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+iceberg_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a iceberg table to scan.                                |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+The path or URL provided to `iceberg_scan` should be to a directory containing
+the `metadata/` and `data/` directories for the table.
+
+## Usage
+
+### Local files
+
+Local Iceberg table can be read with `iceberg_scan` by passing in a path to the
+table. Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM iceberg_scan('./directory/my_iceberg_table/');
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `iceberg_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM iceberg_scan('gs://my-bucket/path/iceberg_table',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM iceberg_scan('gs://my-bucket/path/iceberg_table', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `iceberg_scan`.
+
+```sql
+SELECT * FROM iceberg_scan('gs://my-bucket/path/iceberg_table',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM iceberg_scan('gs://my-bucket/path/iceberg_table', my_aws_creds, region => 'us-east-1');
+```
+
+[Issue #1448]: https://github.com/GlareDB/glaredb/issues/1448

--- a/reference/sql-functions/index.md
+++ b/reference/sql-functions/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: SQL functions
+has_children: true
+nav_order: 2
+parent: Reference
+---
+
+# SQL function reference
+
+Reference docs for builtin SQL functions supported in GlareDB.

--- a/reference/sql-functions/lance_scan.md
+++ b/reference/sql-functions/lance_scan.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: lance_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `lance_scan`
+
+Read a lance table from the local filesystem or supported object store.
+
+## Syntax
+
+```sql
+-- Single url or path.
+lance_scan(<url>)
+-- Using a cloud credentials object.
+lance_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+lance_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+lance_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+lance_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a lance table to scan.                                  |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+The path or URL provided to `lance_scan`
+should be to a directory containing a [lance dataset]
+
+## Usage
+
+### Local files
+
+Local lance table can be read with `lance_scan` by passing in a path to the
+table. Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM lance_scan('./directory/my_lance_table/');
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `lance_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM lance_scan('gs://my-bucket/path/lance_table',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM lance_scan('gs://my-bucket/path/lance_table', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `lance_scan`.
+
+```sql
+SELECT * FROM lance_scan('gs://my-bucket/path/lance_table',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM lance_scan('gs://my-bucket/path/lance_table', my_aws_creds, region => 'us-east-1');
+```
+
+[lance dataset]: (https://lancedb.github.io/lance/format.html#dataset-directory)

--- a/reference/sql-functions/list_columns.md
+++ b/reference/sql-functions/list_columns.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: list_columns
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `list_columns`
+
+List columns for a table.
+
+The database that the tables belong to must be in scope of GlareDB, for example
+as a data source.
+
+For listing columns on a native table, use `"default"` as the database.
+
+## Syntax
+
+```sql
+list_columns(<database>, <schema>, <table>)
+```
+
+| Field      | Description                                |
+| ---------- | ------------------------------------------ |
+| `database` | The name of the database.                  |
+| `schema`   | The name of the schema on the databsae.    |
+| `table`    | The name of the table to list columns for. |
+
+## Examples
+
+In the following example, suppose a Postgres data source was added to GlareDB
+and named `my_pg`:
+
+```sql
+-- list all columns of the public.customers table
+select * from list_columns("my_pg", "public", "customers");
+```
+
+See [CREATE EXTERNAL DATABASE] for adding a database as a data source.
+
+[CREATE EXTERNAL DATABASE]: /glaredb/sql-commands/create-external-database/

--- a/reference/sql-functions/list_schemas.md
+++ b/reference/sql-functions/list_schemas.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: list_schemas
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `list_schemas`
+
+List schemas for a database.
+
+The database must be in scope of GlareDB, for example as a data source.
+
+## Syntax
+
+```sql
+list_schemas(<database>)
+```
+
+| Field      | Description                                   |
+| ---------- | --------------------------------------------- |
+| `database` | The name of the database to list schemas for. |
+
+## Examples
+
+In the following example, suppose a Postgres data source was added to GlareDB
+and named `my_pg`:
+
+```sql
+select * from list_schemas(my_pg);
+```
+
+See [CREATE EXTERNAL DATABASE] for adding a database as a data source.
+
+[CREATE EXTERNAL DATABASE]: /glaredb/sql-commands/create-external-database/

--- a/reference/sql-functions/list_tables.md
+++ b/reference/sql-functions/list_tables.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: list_tables
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `list_tables`
+
+List tables for a schema.
+
+The database where the schema resides must be in scope of GlareDB, for example
+as a data source.
+
+## Syntax
+
+```sql
+list_tables(<database>, <schema>)
+```
+
+| Field      | Description                                |
+| ---------- | ------------------------------------------ |
+| `database` | The name of the database.                  |
+| `schema`   | The name of the schema to list tables for. |
+
+## Examples
+
+In the following example, suppose a Postgres data source was added to GlareDB
+and named `my_pg` and has a `public` schema:
+
+```sql
+select * from list_tables(my_pg, public);
+```
+
+See [CREATE EXTERNAL DATABASE] for adding a database as a data source.
+
+[CREATE EXTERNAL DATABASE]: /glaredb/sql-commands/create-external-database/

--- a/reference/sql-functions/ndjson_scan.md
+++ b/reference/sql-functions/ndjson_scan.md
@@ -1,0 +1,176 @@
+---
+layout: default
+title: ndjson_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `ndjson_scan`
+
+Read newline-delimited json files from a local filesystem or supported object
+stores.
+
+The files may be compressed, for example: `.ndjson.gz`.
+
+URLs provided to `ndjson_scan` may also include glob characters to allow
+scanning multiple files when reading from S3, GCS, or a local filesystem.
+Globbed paths are not allowed when querying json files over HTTP/HTTPS.
+
+## Syntax
+
+```sql
+-- Single url or path.
+ndjson_scan(<url>)
+-- Multiple urls or paths.
+ndjson_scan([<url>])
+-- Using a cloud credentials object.
+ndjson_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+ndjson_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+ndjson_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+ndjson_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a json file to scan.                                    |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+## Usage
+
+### Local files
+
+Local files can be read by passing the path or a globbed path to `ndjson_scan`.
+Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM ndjson_scan('./my_data.json');
+-- Read all json files in a directory.
+SELECT * FROM ndjson_scan('./directory_of_data/*.json');
+-- Read json files from multiple directories.
+SELECT * FROM ndjson_scan('./**/*.json');
+-- Read multiple explicitly provided files.
+SELECT * FROM ndjson_scan(['./directory_of_data/1.json', './directory_of_data/2.json']);
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `ndjson_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/object.json',
+                           service_account_key => '<service_account_key>');
+-- Scan objects matching a glob.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/prefix_*.json',
+                           service_account_key => '<service_account_key>');
+-- Read all objects in a directory.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/*',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/object.json', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `ndjson_scan`.
+
+```sql
+SELECT * FROM ndjson_scan('gs://my-bucket/path/object.json',
+                          access_key_id = '<access_key_id>',
+                          secret_access_key = '<secret_access_key>',
+                          region = 'us-east-1');
+-- Scan objects matching a glob.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/prefix_*.json',
+                          access_key_id = '<access_key_id>',
+                          secret_access_key = '<secret_access_key>',
+                          region = 'us-east-1');
+-- Read all objects in a directory.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/prefix_*.json',
+                          access_key_id = '<access_key_id>',
+                          secret_access_key = '<secret_access_key>',
+                          region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM ndjson_scan('gs://my-bucket/path/object.json', my_aws_creds, region => 'us-east-1');
+```
+
+### HTTP files
+
+Json files can also be scanned over HTTP/HTTPS.
+
+```sql
+-- Read a single file.
+SELECT * FROM ndjson_scan('https://my_domain.com/file.json');
+-- Read multiple files
+SELECT * FROM ndjson_scan(['https://my_domain.com/1.json', 'https://my_domain.com/2.json']);
+```
+
+{: .important}
+
+> Globbed paths are not supported when reading json files over HTTP/HTTPS
+
+## Examples
+
+In the following example we use [COPY TO] to create a json file and finally
+read it with `ndjson_scan`.
+
+```sql
+-- Output the file to 'example.json'
+COPY (SELECT * FROM generate_series(1, 10)) TO 'example.json';
+
+-- And scan it back in.
+SELECT * FROM ndjson_scan('./example.json');
+
+-- Output:
+-- ┌─────────────────┐
+-- │ generate_series │
+-- │ ──              │
+-- │ Int64           │
+-- ╞═════════════════╡
+-- │ 1               │
+-- │ 2               │
+-- │ 3               │
+-- │ 4               │
+-- │ 5               │
+-- │ 6               │
+-- │ 7               │
+-- │ 8               │
+-- │ 9               │
+-- │ 10              │
+-- └─────────────────┘
+```
+
+[COPY TO]: /glaredb/sql-commands/copy-to

--- a/reference/sql-functions/parquet_scan.md
+++ b/reference/sql-functions/parquet_scan.md
@@ -1,0 +1,173 @@
+---
+layout: default
+title: parquet_scan
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `parquet_scan`
+
+Read parquet files from a local filesystem or supported object stores.
+
+URLs provided to `parquet_scan` may also include glob characters to allow
+scanning multiple files when reading from S3, GCS, or a local filesystem.
+Globbed paths are not allowed when querying parquet files over HTTP/HTTPS.
+
+## Syntax
+
+```sql
+-- Single url or path.
+parquet_scan(<url>)
+-- Multiple urls or paths.
+parquet_scan([<url>])
+-- Using a cloud credentials object.
+parquet_scan(<url>, <credential_object>)
+-- Required named argument for S3 buckets.
+parquet_scan(<url>, <credentials_object>, region => '<aws_region>')
+-- Pass S3 credentials using named arguments.
+parquet_scan(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>')
+-- Pass GCS credentials using named arguments.
+parquet_scan(<url>, service_account_key => '<gcp_service_account_key>')
+```
+
+Parameter descriptions and which object store it's relevant to.
+
+| Parameter                 | Object store | Description                                                                |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `url`                     | All          | The URL or path to a parquet file to scan.                                 |
+| `credential_object`       | S3 and GCS   | A database object storing credentials for accessing the object or objects. |
+| `aws_region`              | S3           | If scanning an object in S3, the region of the bucket.                     |
+| `aws_access_key_id`       | S3           | ID of AWS access key with permissions to read from the bucket.             |
+| `aws_secret_access_key`   | S3           | Secret associated with the AWS access key.                                 |
+| `gcp_service_account_key` | GCS          | A JSON-encoded GCP service account key with access to the bucket.          |
+
+## Usage
+
+### Local files
+
+Local files can be read by passing the path or a globbed path to `parquet_scan`.
+Paths may be absolute or relative.
+
+```sql
+-- Read a relative path.
+SELECT * FROM parquet_scan('./my_data.parquet');
+-- Read all parquet files in a directory.
+SELECT * FROM parquet_scan('./directory_of_data/*.parquet');
+-- Read parquet files from multiple directories.
+SELECT * FROM parquet_scan('./**/*.parquet');
+-- Read multiple explicitly provided files.
+SELECT * FROM parquet_scan(['./directory_of_data/1.parquet', './directory_of_data/2.parquet']);
+```
+
+### Objects in GCS
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object to `parquet_scan`. The service account key provided should be
+JSON encoded.
+
+```sql
+-- Single object.
+SELECT * FROM parquet_scan('gs://my-bucket/path/object.parquet',
+                           service_account_key => '<service_account_key>');
+-- Scan objects matching a glob.
+SELECT * FROM parquet_scan('gs://my-bucket/path/prefix_*.parquet',
+                           service_account_key => '<service_account_key>');
+-- Read all objects in a directory.
+SELECT * FROM parquet_scan('gs://my-bucket/path/*',
+                           service_account_key => '<service_account_key>');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_gcp_creds PROVIDER gcp
+    ( service_account_key '<service_account_key>' );
+-- And use them in the scan.
+SELECT * FROM parquet_scan('gs://my-bucket/path/object.parquet', my_gcp_creds);
+```
+
+### Objects in S3
+
+Objects in GCS can be read by providing the path to the object and credentials
+for the object, and the bucket region to `parquet_scan`.
+
+```sql
+SELECT * FROM parquet_scan('gs://my-bucket/path/object.parquet',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+-- Scan objects matching a glob.
+SELECT * FROM parquet_scan('gs://my-bucket/path/prefix_*.parquet',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+-- Read all objects in a directory.
+SELECT * FROM parquet_scan('gs://my-bucket/path/prefix_*.parquet',
+                           access_key_id = '<access_key_id>',
+                           secret_access_key = '<secret_access_key>',
+                           region = 'us-east-1');
+```
+
+Optionally, a credentials object can be created and used in place of providing
+the service account key directly.
+
+```sql
+-- Create the credentials.
+CREATE CREDENTIALS my_aws_creds PROVIDER aws
+    OPTIONS (
+        access_key_id = '<access_key_id>',
+        secret_access_key = '<secret_access_key>',
+    );
+-- And use them in the scan. Note that a region still needs to be provided.
+SELECT * FROM parquet_scan('gs://my-bucket/path/object.parquet', my_aws_creds, region => 'us-east-1');
+```
+
+### HTTP files
+
+Parquet files can also be scanned over HTTP/HTTPS.
+
+```sql
+-- Read a single file.
+SELECT * FROM parquet_scan('https://my_domain.com/file.parquet');
+-- Read multiple files
+SELECT * FROM parquet_scan(['https://my_domain.com/1.parquet', 'https://my_domain.com/2.parquet']);
+```
+
+{: .important}
+
+> Globbed paths are not supported when reading parquet files over HTTP/HTTPS
+
+## Examples
+
+In the following example we use [COPY TO] to create a parquet file and finally
+read it with `parquet_scan`.
+
+```sql
+-- Output the file to 'example.parquet'
+COPY (SELECT * FROM generate_series(1, 10)) TO 'example.parquet';
+
+-- And scan it back in.
+SELECT * FROM parquet_scan('./example.parquet');
+
+-- Output:
+-- ┌─────────────────┐
+-- │ generate_series │
+-- │ ──              │
+-- │ Int64           │
+-- ╞═════════════════╡
+-- │ 1               │
+-- │ 2               │
+-- │ 3               │
+-- │ 4               │
+-- │ 5               │
+-- │ 6               │
+-- │ 7               │
+-- │ 8               │
+-- │ 9               │
+-- │ 10              │
+-- └─────────────────┘
+```
+
+[COPY TO]: /glaredb/sql-commands/copy-to

--- a/reference/sql-functions/read_bigquery.md
+++ b/reference/sql-functions/read_bigquery.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: read_bigquery
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_bigquery`
+
+Read a BigQuery table. The table does not have to be a known data source to
+GlareDB. As long as you can access the table with a service account, it can be
+queried.
+
+## Syntax
+
+```sql
+read_bigquery(<gcp_service_account_key>, <project_id>, <dataset_id>, <table_id>)
+```
+
+| Field                     | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `gcp_service_account_key` | The JSON encoded service account key.             |
+| `project_id`              | The GCP project containing the table of interest. |
+| `dataset_id`              | The dataset ID where the table resides            |
+| `table_id`                | The table ID                                      |
+
+## Examples
+
+In the following example, a 'users' table located in a BigQuery project is
+queryed.
+
+```sql
+select * from read_bigquery(
+  '{<your_service_account_key>}',
+  'example-bigquery-project',
+  'example-dataset',
+  'users'
+);
+```

--- a/reference/sql-functions/read_bson.md
+++ b/reference/sql-functions/read_bson.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: read_bson
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_bson`
+
+Reads one or more BSON files from the local filesystem or supported object store.
+
+## Syntax
+
+```sql
+-- Location of the file or files:
+read_bson(<url>);
+-- Explicitly set the number of documents considered to infer the
+-- schema (default is 100):
+read_bson(<url>, schema_sample_size => 250);
+```
+
+Like other functions that produces table objects in queries,
+`read_bson` works with all supported cloud providers for remote
+storage: GCS, S3, Azure, and compatible APIs.
+
+```sql
+-- Using a cloud credentials object.
+read_bson(<url>, <credential_object>);
+-- Required named argument for S3 buckets.
+read_bson(<url>, <credentials_object>, region => '<aws_region>');
+-- Pass S3 credentials using named arguments.
+read_bson(<url>, access_key_id => '<aws_access_key_id>', secret_access_key => '<aws_secret_access_key>', region => '<aws_region>');
+-- Pass GCS credentials using named arguments.
+read_bson(<url>, service_account_key => '<gcp_service_account_key>');
+```
+
+## Behavior
+
+### Multiple Files
+
+`read_bson` will expand glob patterns in the `<url>` argument and will
+treat the resulting list of files as partitions of the same table.
+
+### Schema Inference
+
+By default, `read_bson`, sorts the files lexicographically and scans the
+first 100 documents to infer the schema. Every field that appears is
+added to the schema in the order that it appears as a nullable
+field. The first type observed becomes the field's type.
+
+After inferring a schema, the remaining data and files may be read
+in any order.
+
+The `schema_sample_size` option allows you to change the number of
+documents considered when inferring the schema.

--- a/reference/sql-functions/read_clickhouse.md
+++ b/reference/sql-functions/read_clickhouse.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: read_clickhouse
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_clickhouse`
+
+Read a ClickHouse table. The table does not have to be a known data source to
+GlareDB.
+
+## Syntax
+
+```sql
+read_clickhouse(<connection_string>, <table>)
+```
+
+| Field               | Description                     |
+| ------------------- | ------------------------------- |
+| `connection_string` | A ClickHouse connection string. |
+| `table`             | The name of the table to query. |
+
+## Examples
+
+In the following example, a 'users' table located in a ClickHouse database is
+queryed.
+
+```sql
+select * from read_clickhouse(
+  'clickhouse://my_user:my_password@my.clickhouse.host:9000/default',
+  'users'
+);
+```
+
+Refer to the [documentation on ClickHouse data sources] for more information.
+
+[documentation on ClickHouse data sources]: /docs/data-sources/supported/clickhouse

--- a/reference/sql-functions/read_excel.md
+++ b/reference/sql-functions/read_excel.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: read_excel
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_excel`
+
+Reads an Excel file from the local filesystem.
+
+## Syntax
+
+```sql
+read_excel(<path>);
+```
+
+| Field  | Description            |
+| ------ | ---------------------- |
+| `path` | Path to the Excel file |
+
+## Examples
+
+Read an Excel sheet named `sheet.xlsx` located in the current directory.
+
+```sql
+SELECT * FROM read_excel('./sheet.xlsx')
+```

--- a/reference/sql-functions/read_mongodb.md
+++ b/reference/sql-functions/read_mongodb.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: read_mongodb
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_mongodb`
+
+Read data from an arbitrary MongoDB collection. The collection does
+not have to be a known data source to GlareDB.
+
+If you have multiple collections in one MongoDB deployment or are
+regularly using the same MongoDB data source, consider [setting up a
+MongoDB data source](/docs/data-sources/supported/mongodb).
+
+## Syntax
+
+```sql
+read_mongodb(<connection_str>, <database>, <collection>)
+```
+
+| Field            | Description                  |
+| ---------------- | ---------------------------- |
+| `connection_str` | A MongoDB connection string. |
+| `database`       | The name of the database.    |
+| `collection`     | The name of the collection.  |
+
+## Examples
+
+In the following example, a 'users' collection is queryed.
+
+```sql
+SELECT mdb.* FROM read_mongodb(
+  'protocol=mongodb+srv, user=mdb_user, password=mdb_user_password',
+  'mdbDatabaseName',
+  'collectionName'
+) AS mdb;
+```
+
+This exposes the fields from the MongoDB collection as a collection of
+fields with the `mdb.` prefix in a SQL query. Select an alternate
+prefix, or no prefix as you see fit.
+
+## Behavior
+
+GlareDB samples up to 100 documents from the MongoDB collection, or
+less for smaller collections, building a schema that has the sum of
+all fields in the observed documents. Follow [this
+issue](https://github.com/GlareDB/glaredb/issues/2144) for discussion
+of changes to schema inference for MongoDB data sources.

--- a/reference/sql-functions/read_mysql.md
+++ b/reference/sql-functions/read_mysql.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: read_mysql
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_mysql`
+
+Read a MySQL table. The table does not have to be a known data source to
+GlareDB.
+
+## Syntax
+
+```sql
+read_mysql(<connection_str>, <schema>, <table>)
+```
+
+| Field            | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `connection_str` | A MySQL connection string.                      |
+| `schema`         | The name of the schema where the table resides. |
+| `table`          | The name of the table to query.                 |
+
+## Examples
+
+In the following example, a 'users' table located in a MySQL database is
+queryed.
+
+```sql
+select * from read_mysql(
+  'host=your.host port=3306 user=mysql password=password database=database',
+  'public',
+  'users'
+);
+```
+
+Refer to the [documentation on MySQL data sources] for more information.
+
+[documentation on MySQL data sources]: /docs/data-sources/supported/mysql

--- a/reference/sql-functions/read_postgres.md
+++ b/reference/sql-functions/read_postgres.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: read_postgres
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_postgres`
+
+Read a Postgres table. The table does not have to be a known data source to
+GlareDB.
+
+## Syntax
+
+```sql
+read_postgres(<connection_str>, <schema>, <table>)
+```
+
+| Field            | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `connection_str` | A Postgres connection string.                   |
+| `schema`         | The name of the schema where the table resides. |
+| `table`          | The name of the table to query.                 |
+
+## Examples
+
+In the following example, a 'users' table located in a Postgres database is
+queryed.
+
+```sql
+select * from read_postgres(
+  'host=your.host port=5432 user=postgres password=postgres database=postgres',
+  'public',
+  'users'
+);
+```
+
+Refer to the [documentation on Postgres data sources] for more information.
+
+[documentation on Postgres data sources]: /docs/data-sources/supported/postgres

--- a/reference/sql-functions/read_snowflake.md
+++ b/reference/sql-functions/read_snowflake.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: read_snowflake
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_snowflake`
+
+Read a table residing in a Snowflake warehouse. The table does not have to be a
+known data source to GlareDB.
+
+## Syntax
+
+```sql
+read_snowflake(
+  <account>,
+  <username>,
+  <password>,
+  <database>,
+  <warehouse>,
+  <role>,
+  <schema>,
+  <table>
+)
+```
+
+| Field       | Description                                               |
+| ----------- | --------------------------------------------------------- |
+| `account`   | Account containing the Snowflake warehouse to connect to. |
+| `username`  | Name of the user to login as.                             |
+| `password`  | Password for the above user.                              |
+| `database`  | Name of the database to connect to.                       |
+| `warehouse` | Name of the warehouse to connect to.                      |
+| `role`      | Role to use when connecting.                              |
+| `schema`    | The name of the schema.                                   |
+| `table`     | The name of the table to query.                           |
+
+## Examples
+
+In the following example, a 'users' table located in a Snowflake warehouse is
+queryed.
+
+```sql
+select * from read_snowflake(
+  'xy12345',
+  'snowflake_username',
+  'snowflake_password',
+  'my_database',
+  'my_warehouse',
+  'USERADMIN',
+  'public',
+  'users'
+);
+```
+
+Refer to the [documentation on Snowflake data sources] for more information.
+
+[documentation on Snowflake data sources]: /docs/data-sources/supported/snowflake

--- a/reference/sql-functions/read_sqlserver.md
+++ b/reference/sql-functions/read_sqlserver.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: read_sqlserver
+parent: SQL functions
+grand_parent: Reference
+---
+
+# `read_sqlserver`
+
+Read a SQL Server table. The table does not have to be a known data source to
+GlareDB.
+
+## Syntax
+
+```sql
+read_sqlserver(<connection_string>, <schema>, <table>)
+```
+
+| Field               | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `connection_string` | A SQL Server connection string.              |
+| `schema`            | The name of the schema containing the table. |
+| `table`             | The name of the table to query.              |
+
+## Examples
+
+In the following example, a 'users' table located in a SQL Server database is
+queryed.
+
+```sql
+select * from read_sqlserver(
+  'server=tcp:my.sqlserver.host,1433;user=SA;password=Password123;TrustServerCertificate=true',
+  'dbo',
+  'users'
+);
+```
+
+Refer to the [documentation on SQL Server data sources] for more information.
+
+[documentation on SQL Server data sources]: /docs/data-sources/supported/sql-server

--- a/reference/sql-operations.md
+++ b/reference/sql-operations.md
@@ -1,8 +1,0 @@
----
-title: SQL Operations
-layout: default
-nav_order: 3
-parent: Reference
----
-
-## SQL Operations

--- a/reference/table-functions.md
+++ b/reference/table-functions.md
@@ -1,8 +1,0 @@
----
-title: Table Functions
-layout: default
-nav_order: 5
-parent: Reference
----
-
-## Table Functions

--- a/reference/window-functions.md
+++ b/reference/window-functions.md
@@ -1,8 +1,0 @@
----
-title: Window Functions
-layout: default
-nav_order: 7
-parent: Reference
----
-
-## Window Functions


### PR DESCRIPTION
Because of how the index pages work, it didn't seem possible to combine these into one page with separate sections. For now, keeping this in pretty much the same structure as before (just nested below reference now).